### PR TITLE
[기타] develop -> main PR 시 미리보기 추가

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,6 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Trigger Amplify Deployment
+        run: |
+          curl -X POST https://api.amplify.aws/apps/<AMPLIFY_APP_ID>/branches/${{ github.head_ref }}/deployments \
+          -H "Authorization: Bearer ${{ secrets.AWS_ACCESS_TOKEN }}" \
+          -H "Content-Type: application/json"
+
       - name: Set Environment Variables
         run: |
           echo "LATEST_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
@@ -32,7 +38,7 @@ jobs:
           script: |
             const { owner, repo, number } = context.issue;
             const commentBody = `
-###🚀 Amplify Preview Success!
+### 🚀 Amplify Preview Success!
 
 | Name                  | Link                                                                 |
 |-----------------------|----------------------------------------------------------------------|

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,10 @@ on:
             - main
         types: [opened, synchronize, reopened]
 
+permissions:
+    issues: write
+    pull-requests: write
+
 jobs:
     preview:
         runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -23,7 +23,7 @@ jobs:
                   aws amplify start-deployment \
                     --app-id d2ggjieg648h6b \
                     --branch-name ${{ github.head_ref }} \
-                    --region us-east-1
+                    --region us-east-2
               env:
                   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,45 +1,49 @@
 name: Amplify Preview Deployment
 
 on:
-    pull_request:
-        branches:
-            - develop
-            - main
-        types: [opened, synchronize, reopened]
+  pull_request:
+    branches:
+      - develop
+      - main
+    types: [opened, synchronize, reopened]
 
 permissions:
-    issues: write
-    pull-requests: write
+  issues: write
+  pull-requests: write
 
 jobs:
-    preview:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v3
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-            - name: Get Amplify Preview URL
-              run: |
-                  BASE_URL="https://develop.d2ggjieg648h6b.amplifyapp.com"
-                  echo "AMPLIFY_URL=${BASE_URL}" >> $GITHUB_ENV
+      - name: Set Environment Variables
+        run: |
+          echo "LATEST_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
+          echo "DEPLOY_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+          echo "DEPLOY_PREVIEW_URL=https://develop.d2ggjieg648h6b.amplifyapp.com" >> $GITHUB_ENV
+          echo "ENVIRONMENT=preview" >> $GITHUB_ENV
 
-            - name: Comment on PR
-              uses: actions/github-script@v6
-              with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  script: |
-                      const { owner, repo, number } = context.issue;
-                      const commentBody = `
-🚀 Amplify Preview Success!
+      - name: Comment on PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number } = context.issue;
+            const commentBody = `
+###🚀 Amplify Preview Success!
 
-- **Latest Commit**: [${process.env.LATEST_COMMIT}](https://github.com/${owner}/${repo}/commit/${process.env.LATEST_COMMIT})
-- **Latest Deploy Log**: [View Logs](${process.env.DEPLOY_LOG_URL})
-- **Deploy Preview URL**: [Preview Environment](${process.env.DEPLOY_PREVIEW_URL})
-- **Environment**: ${process.env.ENVIRONMENT}
+| Name                  | Link                                                                 |
+|-----------------------|----------------------------------------------------------------------|
+| **Latest Commit**     | [${process.env.LATEST_COMMIT}](https://github.com/${owner}/${repo}/commit/${process.env.LATEST_COMMIT}) |
+| **Latest Deploy Log** | [View Logs](${process.env.DEPLOY_LOG_URL})                          |
+| **Deploy Preview URL**| [Preview Environment](${process.env.DEPLOY_PREVIEW_URL})            |
+| **Environment**       | ${process.env.ENVIRONMENT}                                          |
             `;
-                      github.rest.issues.createComment({
-                        owner,
-                        repo,
-                        issue_number: number,
-                        body: commentBody
-                      });
+            github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: number,
+              body: commentBody.trim()
+            });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,9 +1,10 @@
+# develop -> main으로 PR 남길 때 동작 (AWS amplify가 브랜치별 자동 미리보기 지원하지 않음)
+
 name: Amplify Preview Deployment
 
 on:
     pull_request:
         branches:
-            - develop
             - main
         types: [opened, synchronize, reopened]
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,9 +20,13 @@ jobs:
 
             - name: Trigger Amplify Deployment
               run: |
-                  curl -X POST https://api.amplify.aws/apps/d2ggjieg648h6b/branches/${{ github.head_ref }}/deployments \
-                  -H "Authorization: Bearer ${{ secrets.AWS_ACCESS_KEY_ID }}:${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
-                  -H "Content-Type: application/json"
+                  aws amplify start-deployment \
+                    --app-id d2ggjieg648h6b \
+                    --branch-name ${{ github.head_ref }} \
+                    --region us-east-1
+              env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
             - name: Set Environment Variables
               run: |
@@ -39,7 +43,7 @@ jobs:
                       ### 🚀 Amplify Preview Success!
                       | Name                  | Link                                                                 |
                       |-----------------------|----------------------------------------------------------------------|
-                      | **Latest Commit**     | [${env.LATEST_COMMIT}](https://github.com/${owner}/${repo}/commit/${env.LATEST_COMMIT}) |
-                      | **Latest Deploy Log** | [View Logs](${env.DEPLOY_LOG_URL})                          |
-                      | **Deploy Preview URL**| [Preview Environment](${env.DEPLOY_PREVIEW_URL})            |
-                      | **Environment**       | ${env.ENVIRONMENT}                                          |
+                      | **Latest Commit**     | [${{ env.LATEST_COMMIT }}](https://github.com/${{ github.repository }}/commit/${{ env.LATEST_COMMIT }}) |
+                      | **Latest Deploy Log** | [View Logs](${{ env.DEPLOY_LOG_URL }})                          |
+                      | **Deploy Preview URL**| [Preview Environment](${{ env.DEPLOY_PREVIEW_URL }})            |
+                      | **Environment**       | ${{ env.ENVIRONMENT }}                                          |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,34 @@
+name: Amplify Preview Deployment
+
+on:
+    pull_request:
+        branches:
+            - develop
+            - main
+        types: [opened, synchronize, reopened]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Get Amplify Preview URL
+              run: |
+                  BASE_URL="https://develop.d2ggjieg648h6b.amplifyapp.com"
+                  echo "AMPLIFY_URL=${BASE_URL}" >> $GITHUB_ENV
+
+            - name: Comment on PR
+              uses: actions/github-script@v6
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  script: |
+                      const { owner, repo, number } = context.issue;
+                      const commentBody = `🚀 **Amplify Preview URL:** [개발환경 미리보기](${process.env.AMPLIFY_URL})`;
+                      github.rest.issues.createComment({
+                        owner,
+                        repo,
+                        issue_number: number,
+                        body: commentBody
+                      });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Trigger Amplify Deployment
         run: |
-          curl -X POST https://api.amplify.aws/apps/<AMPLIFY_APP_ID>/branches/${{ github.head_ref }}/deployments \
-          -H "Authorization: Bearer ${{ secrets.AWS_ACCESS_TOKEN }}" \
+          curl -X POST https://api.amplify.aws/apps/d2ggjieg648h6b/branches/${{ github.head_ref }}/deployments \
+          -H "Authorization: Bearer ${{ secrets.AWS_ACCESS_KEY_ID }}:${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
           -H "Content-Type: application/json"
 
       - name: Set Environment Variables

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -29,7 +29,14 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
                       const { owner, repo, number } = context.issue;
-                      const commentBody = `🚀 **Amplify Preview URL:** [개발환경 미리보기](${process.env.AMPLIFY_URL})`;
+                      const commentBody = `
+🚀 Amplify Preview Success!
+
+- **Latest Commit**: [${process.env.LATEST_COMMIT}](https://github.com/${owner}/${repo}/commit/${process.env.LATEST_COMMIT})
+- **Latest Deploy Log**: [View Logs](${process.env.DEPLOY_LOG_URL})
+- **Deploy Preview URL**: [Preview Environment](${process.env.DEPLOY_PREVIEW_URL})
+- **Environment**: ${process.env.ENVIRONMENT}
+            `;
                       github.rest.issues.createComment({
                         owner,
                         repo,

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,55 +1,45 @@
 name: Amplify Preview Deployment
 
 on:
-  pull_request:
-    branches:
-      - develop
-      - main
-    types: [opened, synchronize, reopened]
+    pull_request:
+        branches:
+            - develop
+            - main
+        types: [opened, synchronize, reopened]
 
 permissions:
-  issues: write
-  pull-requests: write
+    issues: write
+    pull-requests: write
 
 jobs:
-  preview:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+    preview:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
 
-      - name: Trigger Amplify Deployment
-        run: |
-          curl -X POST https://api.amplify.aws/apps/d2ggjieg648h6b/branches/${{ github.head_ref }}/deployments \
-          -H "Authorization: Bearer ${{ secrets.AWS_ACCESS_KEY_ID }}:${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
-          -H "Content-Type: application/json"
+            - name: Trigger Amplify Deployment
+              run: |
+                  curl -X POST https://api.amplify.aws/apps/d2ggjieg648h6b/branches/${{ github.head_ref }}/deployments \
+                  -H "Authorization: Bearer ${{ secrets.AWS_ACCESS_KEY_ID }}:${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+                  -H "Content-Type: application/json"
 
-      - name: Set Environment Variables
-        run: |
-          echo "LATEST_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
-          echo "DEPLOY_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
-          echo "DEPLOY_PREVIEW_URL=https://develop.d2ggjieg648h6b.amplifyapp.com" >> $GITHUB_ENV
-          echo "ENVIRONMENT=preview" >> $GITHUB_ENV
+            - name: Set Environment Variables
+              run: |
+                  echo "LATEST_COMMIT=${{ github.sha }}" >> $GITHUB_ENV
+                  echo "DEPLOY_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+                  echo "DEPLOY_PREVIEW_URL=https://develop.d2ggjieg648h6b.amplifyapp.com" >> $GITHUB_ENV
+                  echo "ENVIRONMENT=preview" >> $GITHUB_ENV
 
-      - name: Comment on PR
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { owner, repo, number } = context.issue;
-            const commentBody = `
-### 🚀 Amplify Preview Success!
-
-| Name                  | Link                                                                 |
-|-----------------------|----------------------------------------------------------------------|
-| **Latest Commit**     | [${process.env.LATEST_COMMIT}](https://github.com/${owner}/${repo}/commit/${process.env.LATEST_COMMIT}) |
-| **Latest Deploy Log** | [View Logs](${process.env.DEPLOY_LOG_URL})                          |
-| **Deploy Preview URL**| [Preview Environment](${process.env.DEPLOY_PREVIEW_URL})            |
-| **Environment**       | ${process.env.ENVIRONMENT}                                          |
-            `;
-            github.rest.issues.createComment({
-              owner,
-              repo,
-              issue_number: number,
-              body: commentBody.trim()
-            });
+            - name: Comment on PR
+              uses: actions/github-script@v6
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  message: >
+                      ### 🚀 Amplify Preview Success!
+                      | Name                  | Link                                                                 |
+                      |-----------------------|----------------------------------------------------------------------|
+                      | **Latest Commit**     | [${env.LATEST_COMMIT}](https://github.com/${owner}/${repo}/commit/${env.LATEST_COMMIT}) |
+                      | **Latest Deploy Log** | [View Logs](${env.DEPLOY_LOG_URL})                          |
+                      | **Deploy Preview URL**| [Preview Environment](${env.DEPLOY_PREVIEW_URL})            |
+                      | **Environment**       | ${env.ENVIRONMENT}                                          |


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   github actions preview 파일 추가
    - develop -> main 브랜치 PR opened, synchronize, reopened시 AWS amplify로 개발환경 미리보기

## 📌 주의 


-    AWS amplify가 브랜치별 자동 미리보기 지원하지 않으므로, 작업 브랜치 미리보기 기능은 추후 cloudflare pages로 구현 필요해보임
![image](https://github.com/user-attachments/assets/2534599a-e5c6-41b4-b7e0-378f326bdbca)
