### PR TITLE
[빌드] 개발환경 빌드 설정 추가

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,22 @@
+version: 1
+frontend:
+    phases:
+        preBuild:
+            commands:
+                - echo "https://${GITHUB_PAT}:x-oauth-basic@github.com" > ~/.git-credentials
+                - chmod 600 ~/.git-credentials
+                - git config --global credential.helper store
+                - git submodule sync --recursive
+                - git submodule update --init --recursive
+                - export NODE_ENV=development
+
+        build:
+            commands:
+                - yarn install --frozen-lockfile
+                - yarn run build
+    artifacts:
+        baseDirectory: .next
+        files:
+            - "**/*"
+    cache:
+        paths: []

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 const dotenv = require("dotenv");
 const path = require("path");
+const isDev = process.env.NODE_ENV === "development";
 
 // 환경 변수 파일 경로 설정
 const envFilePath = path.resolve(
@@ -39,6 +40,7 @@ const nextConfig = {
         NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
         SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
     },
+    output: isDev ? "standalone" : "export",
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## 🏆 Details

<!-- 실제로 변경한 사항을 설명해주세요.-->

-   환경에 따라 output 조건부 설정
    - 개발환경일 경우 standalone으로 변경하여 SSR 유지
-   amplify.yml에서 development 환경 변수 주입하도록 수정
  
- Next.js에서 next builld는 production 환경임을 가정하기 때문에 package.json에서 development로 주입하면 충돌 가능성이 크다고 합니다.


## 📚 Reference

[NODE_ENV=development next build fails on static 404 and 500 pages](https://github.com/vercel/next.js/issues/25491)
